### PR TITLE
Deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This package is no longer maintained - its funcionality can be found in Express >2.3.3
+# This package is no longer maintained
 
 Very similar to the unmaintained project [express-uncapitalize](https://github.com/jamiesteven/express-uncapitalize), this middleware redirects any requests which contain uppercase chars to their lowercase forms. With two main changes from the original:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This package is no longer maintained - its funcionality can be found in Express >2.3.3
+
 Very similar to the unmaintained project [express-uncapitalize](https://github.com/jamiesteven/express-uncapitalize), this middleware redirects any requests which contain uppercase chars to their lowercase forms. With two main changes from the original:
 
   1. Works with all utf-8 strings in paths


### PR DESCRIPTION
It is no longer used or maintained by us and functionality to make this unnecessary was added to Express in [2011](https://github.com/expressjs/express/blob/master/History.md#233--2011-05-03)

After this is merged I will archive the repo and deprecate the npm package.

Closes #1.